### PR TITLE
Add hash func for UnionSchema

### DIFF
--- a/confluent_kafka/avro/load.py
+++ b/confluent_kafka/avro/load.py
@@ -43,5 +43,6 @@ try:
 
     schema.RecordSchema.__hash__ = _hash_func
     schema.PrimitiveSchema.__hash__ = _hash_func
+    schema.UnionSchema.__hash__ = _hash_func
 except ImportError:
     schema = None


### PR DESCRIPTION
Hey!

I've found a bug (confluent-kafka==0.11.0) using unions at top level in schemes which results in the following error:
```sh
Traceback (most recent call last):              
...                      
  File "/usr/lib/python3.6/site-packages/confluent_kafka/avro/cached_schema_registry_client.py", line 123, in register
    schema_id = schemas_to_id.get(avro_schema, None)                                            
TypeError: unhashable type: 'UnionSchema'
```
You can reproduce it like this:
```python
from confluent_kafka.avro import AvroProducer

value_schema = avro.load('schemas/order.events-value.avsc')
key_schema = avro.load('schemas/order.events-key.avsc')

config = {
    'bootstrap.servers': 'localhost:9092',
    'schema.registry.url': 'http://localhost:8081'
}
producer = AvroProducer(config, default_value_schema=value_schema,
                        default_key_schema=key_schema)

value = {'class': 'OrderCreated', 'data': {'order_id', '1'}}
producer.produce(topic='order.events', key='1', value=value)
producer.flush()
```
order.commands-value.avsc:
```
[
    {
        "type": "record",
        "name": "MessageData",
        "namespace": "order.common",
        "fields": [
            {
                "name": "order_id",
                "doc": "order_id",
                "type": "string",
                "logicalType": "uuid"
            }
        ]
    },
    {
        "name": "commands",
        "namespace": "order",
        "type": "record",
        "doc": "Order commands",
        "fields": [
            {
                "name": "class",
                "doc": "Message class",
                "type": "string"
            },
            {
                "name": "data",
                "doc": "Message data",
                "type": "order.common.MessageData"
            }
        ]
    }
]
```
This PR fixes this issue by manually adding a hash func to `UnionSchema`.